### PR TITLE
Create an end state and generally clean up the walkthrough component

### DIFF
--- a/client/src/PageLayout/components/PasswordWalkthrough/PssswordWalkthrough.scss
+++ b/client/src/PageLayout/components/PasswordWalkthrough/PssswordWalkthrough.scss
@@ -8,6 +8,10 @@ $pageWidth: 350px;
   width: $pageWidth;
 }
 
+.EndStateText {
+  padding: spacing();
+}
+
 .ProgressBarContainer {
   margin-top: spacing(extraLoose);
   width: $pageWidth + (spacing(loose) * 2);

--- a/client/src/PageLayout/components/PasswordWalkthrough/components/PasswordCreation/PasswordCreation.tsx
+++ b/client/src/PageLayout/components/PasswordWalkthrough/components/PasswordCreation/PasswordCreation.tsx
@@ -16,7 +16,7 @@ enum Type {
 interface Props {
   showModal: boolean;
   passwordOptions: number;
-  generatedPassword: number[];
+  password: number[];
   step: number;
   passwordStackElements: { type: string; color: string; icon: string }[];
   closeModal(): void;
@@ -49,7 +49,7 @@ export default class PasswordCreation extends React.Component<Props, State> {
     const {
       showModal,
       passwordOptions,
-      generatedPassword,
+      password,
       step,
       passwordStackElements,
       closeModal,
@@ -87,7 +87,7 @@ export default class PasswordCreation extends React.Component<Props, State> {
           <XylophoneContainer
             type={Type.creation}
             numberOfKeys={passwordOptions}
-            password={generatedPassword}
+            password={password}
             practiceMode={practiceMode}
             stopPracticing={this.stopPracticing}
             showToast={showToast}

--- a/client/src/PageLayout/components/PasswordWalkthrough/components/components/ProgressBar/ProgressBar.tsx
+++ b/client/src/PageLayout/components/PasswordWalkthrough/components/components/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+
+import { ProgressBar as PolarisProgressBar } from "@shopify/polaris";
+
+import { flow } from "../../../flow";
+
+interface Props {
+  step: number;
+  text?: string;
+}
+
+export default class ProgressBar extends React.Component<Props> {
+  public render() {
+    const { step, text = "Progress" } = this.props;
+
+    const totalSteps = flow(
+      [],
+      []
+    ).length;
+
+    const progressionPercentage = this.calculatePercentage(step, totalSteps);
+
+    return (
+      <div className="ProgressBarContainer">
+        <div className="ProgressText">{text}</div>
+        <PolarisProgressBar
+          progress={this.dropDecimals(progressionPercentage)}
+        />
+      </div>
+    );
+  }
+
+  private calculatePercentage(current: number, total: number) {
+    return (current / total) * 100;
+  }
+
+  private dropDecimals(number: number) {
+    return Math.trunc(number);
+  }
+}

--- a/client/src/PageLayout/components/PasswordWalkthrough/components/components/ProgressBar/index.ts
+++ b/client/src/PageLayout/components/PasswordWalkthrough/components/components/ProgressBar/index.ts
@@ -1,0 +1,3 @@
+import ProgressBar from "./ProgressBar";
+
+export default ProgressBar;


### PR DESCRIPTION
Closes https://github.com/LauraAubin/Xylo/issues/39

Notable change: Created [`defaultPasswordProps`](https://github.com/LauraAubin/Xylo/compare/end-card?expand=1#diff-3d8843724cc1126081557f5fee0f3937R111) so that we don't have to duplicate all of these props on both the `PasswordCreation` and `PasswordRecall` components.